### PR TITLE
Fix airbrake url. Change to api.airbrake.io since airbrakeapp.com is no longer valid

### DIFF
--- a/src/main/java/hoptoad/HoptoadNotifier.java
+++ b/src/main/java/hoptoad/HoptoadNotifier.java
@@ -23,7 +23,7 @@ public class HoptoadNotifier
 
     private HttpURLConnection createConnection() throws IOException
     {
-        final HttpURLConnection connection = (HttpURLConnection) new URL("http://airbrakeapp.com/notifier_api/v2/notices").openConnection();
+        final HttpURLConnection connection = (HttpURLConnection) new URL("http://api.airbrake.io/notifier_api/v2/notices").openConnection();
         return connection;
     }
 


### PR DESCRIPTION
Fix airbrake url. The api endpoint "airbrakeapp.com" is no longer a valid domain.  
Change it to "api.airbrake.io".
